### PR TITLE
Add support for `screen` configuration objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,6 +72,13 @@ module.exports = function(customVariableName, opts) {
               rootArray[varName] = value;
             });
 
+          } else if (key === 'screens' && isObject(keyValue[name])) {
+            const minWEntries = Object.entries(keyValue[name]).filter(e => e[0] === 'min')
+
+            minWEntries.forEach(([_, screenValue]) => {
+              varName = `-${modulePrefix !== '' ? modulePrefix : ''}${name !== 'default' ? '-' + name.replace('/','-') : ''}`;
+              rootArray[varName] = screenValue.toString();
+            })
           } else {
             varName = `-${key !== 'screens' ? '-': ''}${modulePrefix !== '' ? modulePrefix : ''}${
               name !== 'default' ? '-' + name.replace('/','-') : ''


### PR DESCRIPTION
Hi there - Thanks for the great plugin! I noticed an issue when using an object as a config value:

Tailwind config:

```js
screens: {
  xs: { min: '320px', max: '639px' },
  sm: { min: '640px', max: '767px' },
  md: { min: '768px', max: '1023px' },
  lg: { min: '1024px', max: '1279px' },
  xl: { min: '1280px', max: '1439px' }
},
```

CSS output:
```css
:root {
  --xs: [object Object];
  --sm: [object Object];
  --md: [object Object];
  --lg: [object Object];
  --xl: [object Object];  
}
```

This PR should fix it by destructing the config objects and using the `min` value.

Note: I just recently started using TailwindCSS and tested the current PR only with my local TW config. Could be that I missed something.. But so far it seems to work fine.