### PR TITLE
Fix README where plugins accept object instead of array

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ In `tailwind.js` or `tailwind.config.js` search for plugins section and add this
 By defauts, you don't need any configurations.
 
 ```js
-plugins: {
+plugins: [
   require('tailwind-css-variables')(
     {
       // modules
@@ -35,7 +35,7 @@ plugins: {
       // options
     }
   );
-}
+]
 ```
 
 ## Settings


### PR DESCRIPTION
Ref: https://github.com/tailwindcss/plugin-examples