### PR TITLE
feat: export css variables to a separate file

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,17 @@ You can easily disable the module by giving it a value of `false`
 
 ```js
 {
+  outputToFile: true; // default: false
+  outputFilePath: './path/to/file.css'; // default: null
   postcssEachVariables: true; // default: false
 }
 ```
+
+### outputToFile
+This option can be set to `true` if you want to extract the `:root {}` variables into a separate file so that they are not apart of the tailwind.css output.
+
+### outputFilePath
+This option is the relative path to the file you wish to write to. By specifiying the path eg. `./dist/css/variables.css`, the plugin will create that file and populate it with the `:root {}` variables.
 
 ### postcssEachVariables
 

--- a/index.js
+++ b/index.js
@@ -105,7 +105,7 @@ module.exports = function(customVariableName, opts) {
 
       fs.writeFile(options.outputFilePath, outputString, (err) => {
         if (err) throw err;
-        console.log('Created file: ./dist/css/variables.css');
+        console.log(`Created file: ${options.outputFilePath}`);
       });
     } else {
       addComponents(root);

--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ module.exports = function(customVariableName, opts) {
       ':root': rootArray
     };
 
-    if (options.outputToFile) {
+    if (options.outputToFile && options.outputFilePath) {
       const cssVariables = Object.entries(rootArray);
       let outputString = ":root {\n";
       cssVariables.forEach((variable) => outputString += `\t${variable[0]}: ${variable[1]};\n`);

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+const fs = require('fs');
+
 module.exports = function(customVariableName, opts) {
   return ({ addComponents, config }) => {
     const varModules = {

--- a/index.js
+++ b/index.js
@@ -94,7 +94,20 @@ module.exports = function(customVariableName, opts) {
     let root = {
       ':root': rootArray
     };
-    addComponents(root);
+
+    if (options.outputToFile) {
+      const cssVariables = Object.entries(rootArray);
+      let outputString = ":root {\n";
+      cssVariables.forEach((variable) => outputString += `\t${variable[0]}: ${variable[1]};\n`);
+      outputString += "}\n";
+
+      fs.writeFile(options.outputFilePath, outputString, (err) => {
+        if (err) throw err;
+        console.log('Created file: ./dist/css/variables.css');
+      });
+    } else {
+      addComponents(root);
+    }
   };
 };
 


### PR DESCRIPTION
This feature enables users to export the CSS variables into an separate file so that they are not bundled with the compiled tailwind.css file. This enables portability and easy theming across multiple sites & design systems that are derived from a single tailwind.css file.

This is a personal use case I'm facing and rather hacking the installed node_module files, I would love to see this feature supported in the distributed package.

There are two new options that are checked `outputToFile` and `outputFilePath`. Descriptions of their use can be found in the README.