### PR TITLE
allow font stack as string

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ const flattenFontFamily = (obj) => {
   return Object.entries(obj).reduce((prevObj, [key, value]) => {
     return {
       ...prevObj,
-      [key]: value.join(","),
+      [key]: typeof value === 'string' ? value : value.join(","),
     };
   }, {});
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,28 @@
+{
+  "name": "tailwind-css-variables",
+  "version": "3.0.1",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tailwind-css-variables",
+      "version": "3.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    }
+  },
+  "dependencies": {
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -12,5 +12,8 @@
   "keywords": [
     "tailwindcss",
     "css variables"
-  ]
+  ],
+  "dependencies": {
+    "lodash": "^4.17.21"
+  }
 }


### PR DESCRIPTION
The changes in this PR allow the developer to define the font stack in their tailwind config as a string.

Moreover, I added `lodash` to the dependencies as not every project might use it. (That was the case for my project)